### PR TITLE
Fixed paths with CocoaPods 0.35

### DIFF
--- a/lcl_configure
+++ b/lcl_configure
@@ -316,10 +316,10 @@ def configure_pod_components_embedded(pod_dir, pod_name, components_file, embed_
 end
 
 def configure_pod_components_embedded_create_local_config_file(pod_name, file_name)
-  complete_file_name = "Pods/BuildHeaders/#{pod_name}/" + file_name
+  complete_file_name = "Pods/Headers/Build/#{pod_name}/" + file_name
 
   # Create pod-local lcl_config_*.h file.
-  content = "#include \"../../../#{file_name}\"\n"
+  content = "#include \"../../../../#{file_name}\"\n"
   if (!exists_file(complete_file_name) or File.read(complete_file_name) != content)
     info("Creating configuration file '#{complete_file_name}'")
     replace_file(complete_file_name, content)


### PR DESCRIPTION
Not sure when it broke cause I went from CocoaPods 0.33.1 to 0.35 today.

Was getting this error:

```
Using LibComponentLogging-Core (core)
Using LibComponentLogging-NSLogger (NSLogger logger)
Using RestKit (un-embedded RestKit/RK)
Creating configuration file 'Pods/BuildHeaders/RestKit/lcl_config_components.h'
./Pods/LibComponentLogging-pods/configure/lcl_configure:142:in `initialize': No such file or directory @ rb_sysopen - Pods/BuildHeaders/RestKit/lcl_config_components.h (Errno::ENOENT)
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:142:in `open'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:142:in `replace_file'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:325:in `configure_pod_components_embedded_create_local_config_file'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:309:in `block in configure_pod_components_embedded'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:308:in `each'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:308:in `configure_pod_components_embedded'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:558:in `block in configure_pod'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:540:in `each'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:540:in `configure_pod'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:609:in `block in main'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:608:in `chdir'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:608:in `main'
    from ./Pods/LibComponentLogging-pods/configure/lcl_configure:618:in `<main>'
```
